### PR TITLE
[ND-65] Fix infinite loop in `GamesListContainer`

### DIFF
--- a/frontend/src/components/GamesList/GamesList.Container.js
+++ b/frontend/src/components/GamesList/GamesList.Container.js
@@ -8,8 +8,10 @@ import { gamesFetch } from 'redux/games/utils';
 
 const GamesListContainer = ({ games, gamesFetch }) => {
   useEffect(() => {
-    gamesFetch();
-  }, []);
+    if (!games.length) {
+      gamesFetch();
+    }
+  }, [games, gamesFetch]);
 
   return <GamesList games={games} />;
 };


### PR DESCRIPTION
Added a simple `gamesInStore` array length check in `useEffect` to prevent infinite data fetching caused by constant mounting/unmounting `SpinnerLocal` and `GamesList` components.