### PR TITLE
[ND-66] Fix issue with `sizeUnit` prop of `SpinnerLocal`

### DIFF
--- a/frontend/src/components/SpinnerLocal/SpinnerLocal.js
+++ b/frontend/src/components/SpinnerLocal/SpinnerLocal.js
@@ -5,7 +5,12 @@ import { colors } from 'utils/colors';
 
 const SpinnerLocal = () => (
   <S.SpinnerLocalContainer>
-    <PacmanLoader color={colors.text.secondary.hex} size={50} sizeUnit='50' />
+    <PacmanLoader
+      color={colors.text.secondary.hex}
+      css={S.spinnerLocalCss}
+      size={50}
+      sizeUnit='px'
+    />
   </S.SpinnerLocalContainer>
 );
 

--- a/frontend/src/components/SpinnerLocal/SpinnerLocal.styles.js
+++ b/frontend/src/components/SpinnerLocal/SpinnerLocal.styles.js
@@ -1,4 +1,6 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
+
+import { colors } from 'utils';
 
 const SpinnerLocalContainer = styled.div`
   align-items: center;
@@ -13,4 +15,17 @@ const SpinnerLocalContainer = styled.div`
   min-width: 200px;
 `;
 
-export { SpinnerLocalContainer };
+const spinnerLocalCss = css`
+  transform: translateX(-167%);
+
+  & > div:nth-of-type(-n + 2) {
+    z-index: 100;
+  }
+
+  & > div:nth-last-of-type(-n + 4) {
+    background-color: ${colors.text.primary.hex};
+    z-index: 99;
+  }
+`;
+
+export { SpinnerLocalContainer, spinnerLocalCss };


### PR DESCRIPTION
`sizeUnit` prop in a loader had an incorrect value and therefore was not being displayed. Changed the value to `px` and added some minor styling improvements (centering, color change).