### PR TITLE
[ND-56] Add pagination [BE]

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -5058,6 +5058,21 @@
       "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
       "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
     },
+    "mongoose-paginate": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/mongoose-paginate/-/mongoose-paginate-5.0.3.tgz",
+      "integrity": "sha1-165J7Vv2Tx9692IOqGW2cFjFU3E=",
+      "requires": {
+        "bluebird": "3.0.5"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.0.5.tgz",
+          "integrity": "sha1-L/nQfJs+2ynW0oD+B1KDZefs05I="
+        }
+      }
+    },
     "mpath": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.6.0.tgz",

--- a/backend/package.json
+++ b/backend/package.json
@@ -30,6 +30,7 @@
     "express": "^4.17.1",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^5.7.9",
+    "mongoose-paginate": "^5.0.3",
     "passport": "^0.4.0",
     "passport-jwt": "^4.0.0",
     "passport-local": "^1.0.0",

--- a/backend/src/controllers/games/getGames.js
+++ b/backend/src/controllers/games/getGames.js
@@ -1,18 +1,20 @@
+const { isInt } = require('validator');
+
 const Game = require('../../models/Game');
 
-const getGames = async (req, res) => {
+async function getGames(req, res, next) {
   try {
-    const totalCount = await Game.countDocuments();
-    const limit = Number(req.query.limit) || totalCount;
-    const games = await Game.find({}).limit(limit);
+    const { limit = '15', page = '1' } = req.query;
 
-    res.status(200).json({
-      totalCount,
-      games,
-    });
-  } catch (error) {
-    res.status(500).send('Internal server error');
+    if (isInt(limit, { min: 1 }) && isInt(page, { min: 1 })) {
+      const games = await Game.paginate({}, { limit: +limit, page: +page });
+      return res.status(200).json(games);
+    }
+
+    return res.status(400).send('Invalid query parameters.');
+  } catch (err) {
+    next(err);
   }
-};
+}
 
 module.exports = getGames;

--- a/backend/src/controllers/games/index.js
+++ b/backend/src/controllers/games/index.js
@@ -1,0 +1,5 @@
+const getGames = require('./getGames');
+
+module.exports = {
+  getGames,
+};

--- a/backend/src/models/Game.js
+++ b/backend/src/models/Game.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const paginate = require('mongoose-paginate');
 
 const schema = new mongoose.Schema({
   cover: String,
@@ -8,5 +9,9 @@ const schema = new mongoose.Schema({
   rate: Number,
   summary: String,
 });
+
+schema.plugin(paginate);
+
 const Game = mongoose.model('game', schema);
+
 module.exports = Game;

--- a/backend/src/routes/gamesRoutes.js
+++ b/backend/src/routes/gamesRoutes.js
@@ -1,8 +1,8 @@
 const { Router } = require('express');
-const getGames = require('../controllers/games/getGames');
+const gamesControllers = require('../controllers/games');
 
 const router = Router();
 
-router.get('/', getGames);
+router.get('/', gamesControllers.getGames);
 
 module.exports = router;

--- a/frontend/src/redux/games/reducer.js
+++ b/frontend/src/redux/games/reducer.js
@@ -18,9 +18,9 @@ export default function gamesReducer(state = INITIAL_STATE, action) {
       return {
         ...state,
         error: null,
-        gamesInStore: action.payload.games.games,
+        gamesInStore: action.payload.games.docs,
         loading: false,
-        total: action.payload.games.totalCount
+        total: action.payload.games.total
       };
     case types.GAMES_FETCH_FAILURE:
       return {


### PR DESCRIPTION
Used `mongoose-paginate` to create pagination.
`api/games` route now takes two optional query parameters: `limit` (defaults to 15) and `page` (defaults to 1) which have to be positive integers, otherwise backend responses with status code 400.
A valid request returns JSON which looks like this:
```
{
    "docs": [], //array with games' data
    "total": 144,
    "limit": 15,
    "page": 1,
    "pages": 10
}